### PR TITLE
Render close control button link as QR

### DIFF
--- a/src/common/components.scss
+++ b/src/common/components.scss
@@ -957,6 +957,17 @@
     }
   }
 
+  @include phone {
+    .hide-phone {
+      display: none !important;
+    }
+  }
+  @include from-phone {
+    .only-phone {
+      display: none !important;
+    }
+  }
+
   @import '../common/components/loader';
   @import '../common/components/input';
   @import '../common/components/modal';

--- a/src/common/components.scss
+++ b/src/common/components.scss
@@ -957,17 +957,6 @@
     }
   }
 
-  @include phone {
-    .hide-phone {
-      display: none !important;
-    }
-  }
-  @include from-phone {
-    .only-phone {
-      display: none !important;
-    }
-  }
-
   @import '../common/components/loader';
   @import '../common/components/input';
   @import '../common/components/modal';

--- a/src/common/components/input_method.scss
+++ b/src/common/components/input_method.scss
@@ -364,7 +364,9 @@
   div.content {
     background-color: #f0f0f0;
     padding: 24px;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     .loader {
       position: relative;
@@ -375,10 +377,14 @@
 
     .closed {
       display: inline-block;
-      height: 4em;
-      width: 4em;
       position: relative;
       svg {
+        height: 4em;
+        width: 4em;
+      }
+      img.qr {
+        height: 14em;
+        width: 14em;
       }
     }
 

--- a/src/components/input_method/Wait.tsx
+++ b/src/components/input_method/Wait.tsx
@@ -47,7 +47,7 @@ function renderButton(
 
     return <>
       <button className="only-phone" onClick={() => buttonClick(button, props.handler, onClick)}>{button.title}</button>
-      <img className="hide-phone" src={qrCodeUrl} />
+      <img title={button.title} className="hide-phone" src={qrCodeUrl} />
     </>
   }
 

--- a/src/components/input_method/Wait.tsx
+++ b/src/components/input_method/Wait.tsx
@@ -7,6 +7,7 @@ import { TextUtil } from '@botsquad/sdk'
 import { useInputMethodProps, useInputMethodPropsUpdate } from './InputMethodContext'
 import InputMethodTemplate from 'components/elements/InputMethodTemplate'
 import { ChatHandler } from 'components'
+import { isMobile } from '../../common/util'
 
 interface renderImplicitCloseButtonProps {
   type: string
@@ -42,13 +43,8 @@ function renderButton(
   const onClick = (payload: any) =>
     props.inputModal?.finish('message', { type: 'wait', text: button.title, data: { event: payload } }, props.config)
 
-  if (button.type === 'web_url' && button.url && props.config.show_qr) {
-    const qrCodeUrl = 'https://bsqd.me/api/qr/?size=200x200&data=' + encodeURIComponent(button.url)
-
-    return <>
-      <button className="only-phone" onClick={() => buttonClick(button, props.handler, onClick)}>{button.title}</button>
-      <img title={button.title} className="hide-phone" src={qrCodeUrl} />
-    </>
+  if (button.type === 'web_url' && button.url && props.config.show_qr && !isMobile()) {
+    return null
   }
 
   return <button onClick={() => buttonClick(button, props.handler, onClick)}>{button.title}</button>
@@ -104,6 +100,14 @@ const Wait: React.FC<WaitProps> = props => {
     updateValues('inline', type === 'closed')
   }, [type])
   const renderButtonProps = { config, inputModal, handler }
+
+  let closedElement: any = Closed
+
+  if (button.type === 'web_url' && button.url && config.show_qr && !isMobile()) {
+    const qrCodeUrl = 'https://bsqd.me/api/qr/?size=200x200&data=' + encodeURIComponent(button.url)
+    closedElement = <img className="qr" title={button.title} src={qrCodeUrl} />
+  }
+
   return (
     <InputMethodContainer
       {...props}
@@ -112,7 +116,7 @@ const Wait: React.FC<WaitProps> = props => {
     >
       {type === 'wait' && typeof wait_time !== 'undefined' && <div className="loader" />}
 
-      {props.type === 'closed' ? <span className="closed">{Closed}</span> : null}
+      {props.type === 'closed' ? <span className="closed">{closedElement}</span> : null}
 
       {description ? <div className="description" dangerouslySetInnerHTML={TextUtil.processText(description)} /> : null}
 

--- a/src/components/input_method/Wait.tsx
+++ b/src/components/input_method/Wait.tsx
@@ -42,6 +42,15 @@ function renderButton(
   const onClick = (payload: any) =>
     props.inputModal?.finish('message', { type: 'wait', text: button.title, data: { event: payload } }, props.config)
 
+  if (button.type === 'web_url' && button.url && props.config.show_qr) {
+    const qrCodeUrl = 'https://bsqd.me/api/qr/?size=200x200&data=' + encodeURIComponent(button.url)
+
+    return <>
+      <button className="only-phone" onClick={() => buttonClick(button, props.handler, onClick)}>{button.title}</button>
+      <img className="hide-phone" src={qrCodeUrl} />
+    </>
+  }
+
   return <button onClick={() => buttonClick(button, props.handler, onClick)}>{button.title}</button>
 }
 


### PR DESCRIPTION
Given the following Bubble:

```elixir
show input_method("closed", button: [type: "web_url", url: "https://example.com", title: "Example"], show_qr: true)
```

Renders the following on desktop:

![image](https://user-images.githubusercontent.com/104429717/165960987-6ca73130-a6d4-4262-aa2c-c3bf1fde4473.png)

And on mobile:

![image](https://user-images.githubusercontent.com/104429717/165961052-d5b00709-2a35-4a15-8c83-ce62eef8d8df.png)
