### PR TITLE
Fix default value in date picker input method

### DIFF
--- a/src/components/input_method/DatePicker.tsx
+++ b/src/components/input_method/DatePicker.tsx
@@ -14,12 +14,17 @@ interface Props {
 
 const DatePicker: React.FC<Props> = ({ settings }) => {
   const { config, inputModal, localePrefs } = useInputMethodProps<InputMethodDatePicker>()
-  const [label, setLabel] = useState<string>('')
-  const [value, setValue] = useState<string>('')
+  const { confirm, button_label, default_value, constraints } = config
+
+  const [value, setValue] = useState<string>(() => {
+    const defaultValueDate = moment(default_value)
+
+    return defaultValueDate.isValid() ? defaultValueDate.format('YYYY-MM-DD') : ''
+  })
+  const [label, setLabel] = useState<string>(value ? moment(value).format('D-M-Y') : '')
 
   const submit = (value: string, label: string) =>
     inputModal?.finish('message', { type: 'date_picker', text: label, data: value }, config)
-  const { confirm, button_label, default_value, constraints } = config
 
   return (
     <InputMethodContainer
@@ -33,7 +38,6 @@ const DatePicker: React.FC<Props> = ({ settings }) => {
       }
     >
       <Datetime
-        initialValue={moment(default_value || '')}
         input={false}
         value={moment(value) || moment()}
         onChange={date => {

--- a/src/components/input_method/DatePicker.tsx
+++ b/src/components/input_method/DatePicker.tsx
@@ -39,7 +39,7 @@ const DatePicker: React.FC<Props> = ({ settings }) => {
     >
       <Datetime
         input={false}
-        value={moment(value) || moment()}
+        value={moment(value).isValid() ? moment(value) : moment()}
         onChange={date => {
           const value = moment(date).format('YYYY-MM-DD')
           const label = moment(date).format('D-M-Y')


### PR DESCRIPTION
`initialValue` is only for uncontrolled mode, but we're using the controller mode since we're also passing value.

`moment('')` results in an invalid date time, so that is checked now too.